### PR TITLE
Simple enemies no longer spawn near players

### DIFF
--- a/src/com/codecool/snake/Game.java
+++ b/src/com/codecool/snake/Game.java
@@ -6,20 +6,29 @@ import com.codecool.snake.entities.snakes.SnakeHead;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Game extends Pane {
 
     public Game() {
+        List<SnakeHead> players = new ArrayList<>(2);
+        SnakeHead player1, player2;
+
         if(Globals.coop) {
-            new SnakeHead(this, "Player1", 700, 500);
-            new SnakeHead(this, "Player2", 300, 500);
+            player1 = new SnakeHead(this, "Player1", 700, 500);
+            player2 = new SnakeHead(this, "Player2", 300, 500);
+            players.add(player2);
         } else {
-            new SnakeHead(this, "Player1", 500, 500);
+            player1 = new SnakeHead(this, "Player1", 500, 500);
         }
 
-        new SimpleEnemy(this);
-        new SimpleEnemy(this);
-        new SimpleEnemy(this);
-        new SimpleEnemy(this);
+        players.add(player1);
+
+        new SimpleEnemy(this, players);
+        new SimpleEnemy(this, players);
+        new SimpleEnemy(this, players);
+        new SimpleEnemy(this, players);
 
         new SimplePowerup(this);
         new SimplePowerup(this);

--- a/src/com/codecool/snake/Globals.java
+++ b/src/com/codecool/snake/Globals.java
@@ -15,6 +15,9 @@ public class Globals {
     public static final double WINDOW_WIDTH = 1000;
     public static final double WINDOW_HEIGHT = 700;
 
+    public static final short PLAYER_SPRITE_SIZE = 30;
+    public static final short SPAWN_CLEARANCE_MULTIPLIER = 6;
+
     public static Image p1snakeHead = new Image("p1_snake_head.png");
     public static Image p1snakeBody = new Image("p1_snake_body.png");
     public static Image p2snakeHead = new Image("p2_snake_head.png");

--- a/src/com/codecool/snake/entities/enemies/SimpleEnemy.java
+++ b/src/com/codecool/snake/entities/enemies/SimpleEnemy.java
@@ -9,7 +9,10 @@ import com.codecool.snake.entities.snakes.SnakeHead;
 import javafx.geometry.Point2D;
 import javafx.scene.layout.Pane;
 
+import java.util.List;
 import java.util.Random;
+
+import static com.codecool.snake.Globals.SPAWN_CLEARANCE_MULTIPLIER;
 
 // a simple enemy TODO make better ones.
 public class SimpleEnemy extends GameEntity implements Animatable, Interactable {
@@ -17,15 +20,34 @@ public class SimpleEnemy extends GameEntity implements Animatable, Interactable 
     private Point2D heading;
     private static final int damage = 10;
 
-    public SimpleEnemy(Pane pane) {
+    public SimpleEnemy(Pane pane, List<SnakeHead> players) {
         super(pane);
 
         setImage(Globals.simpleEnemy);
         pane.getChildren().add(this);
         int speed = 1;
         Random rnd = new Random();
-        setX(rnd.nextDouble() * Globals.WINDOW_WIDTH);
-        setY(rnd.nextDouble() * Globals.WINDOW_HEIGHT);
+        boolean locationIsOccupied = true;
+        while (locationIsOccupied) {
+            double newX = rnd.nextDouble() * Globals.WINDOW_WIDTH;
+            double newY = rnd.nextDouble() * Globals.WINDOW_HEIGHT;
+
+            for (SnakeHead player : players) {
+                if (
+                        newX > player.getX() - (Globals.PLAYER_SPRITE_SIZE * SPAWN_CLEARANCE_MULTIPLIER) &&
+                        newX < player.getX() + (Globals.PLAYER_SPRITE_SIZE * SPAWN_CLEARANCE_MULTIPLIER) &&
+                        newY > player.getY() - (Globals.PLAYER_SPRITE_SIZE * SPAWN_CLEARANCE_MULTIPLIER) &&
+                        newY < player.getY() + (Globals.PLAYER_SPRITE_SIZE * SPAWN_CLEARANCE_MULTIPLIER)
+                ) {
+                    locationIsOccupied = true;
+                    break;
+                } else {
+                    setX(newX);
+                    setY(newY);
+                    locationIsOccupied = false;
+                }
+            }
+        }
 
         double direction = rnd.nextDouble() * 360;
         setRotate(direction);


### PR DESCRIPTION
If you want to check out the functionality before merging, you can see it working well, by spawning a lot more simple enemies (in `Game`) and you can tweak the new global variable `SPAWN_CLEARANCE_MULTIPLIER`.